### PR TITLE
feat: map backspace key to backspace function

### DIFF
--- a/src/components/Calculator.js
+++ b/src/components/Calculator.js
@@ -24,18 +24,24 @@ export default function Calculator(props) {
             const keyboardRegex = /[0-9]|\+|-|\*|\/|\(|\)|\.|\^/;
 
             if(keyboardRegex.test(event.key) === true) {
+                // case for regular input (i.e. numbers or operators)
                 setCalcState(prevState => prevState + event.key);
                 event.preventDefault();
             } else if(event.key === "=" || event.key === "Enter") {
+                // case for "=" or enter i.e. evaluation
                 equalsAction();
                 event.preventDefault();
+            } else if(event.key === "Backspace") {
+                // case for backspace
+                backAction();
             }
         }
     }
 
     /**
-     * Method to handle evaluating the input. Calls equalsAction, then
-     * sets calcState and answer to this new value.
+     * Function to handle evaluating the input. 
+     * Calls equalsAction, then sets calcState and answer to 
+     * the returned value.
      */
     function equalsAction() {
         const ans = evaluateRPN(calcState, answer);
@@ -45,12 +51,21 @@ export default function Calculator(props) {
     }
 
     /**
-     * Method to handle clearing the calculator screen. Sets calcState to empty
-     * string.
+     * Function to handle clearing the calculator screen. 
+     * Sets calcState to an empty string.
+     * Notably answer is not reset, since users might still
+     * need it in other equations.
      */
     function clearAction() {
         setCalcState("");
-        // don't reset the answer, we still need it
+    }
+
+    /**
+     * Function to handle removing the last character of 
+     * calcState.
+     */
+    function backAction() {
+        setCalcState(prevState => prevState.slice(0, prevState.length - 1));
     }
 
     // sets keydown listener on window to handle keyboard input
@@ -91,7 +106,7 @@ export default function Calculator(props) {
                     <NumberButton style={props.style} value={")"} onClick={addToState} />
                     <NumberButton style={props.style} value={"."} onClick={addToState} />
                     <NumberButton style={props.style} value={"^"} onClick={addToState} />
-                    <NumberButton style={props.style} value={"ANS"} onClick={addToState} />
+                    <NumberButton style={props.style} value={"A"} onClick={addToState} />
                 </span>
                 <span className="calculator--functions">
                     <NumberButton style={props.style} value={"+"} onClick={addToState} />
@@ -103,7 +118,7 @@ export default function Calculator(props) {
                 <span className="calculator--controls">
                     <button 
                         style={props.style}
-                        onClick={() => setCalcState(prevState => prevState.slice(0, prevState.length - 1))}
+                        onClick={backAction}
                     >BACK</button>
                     <button 
                         style={props.style}

--- a/src/components/logic.js
+++ b/src/components/logic.js
@@ -21,7 +21,7 @@ function inputToRPN(val, ans) {
     for(let i = 0; i < nums.length; i++) {
         if(nums[i] === "O") {
             inArray.push(ops[opsCounter++]);
-        } else if(nums[i] === "ANS") {
+        } else if(nums[i] === "A") {
             inArray.push(ans);
         } else if(nums[i] !== "") { 
             // fix for error caused by split treating the gap between ops and brackets as an element
@@ -175,7 +175,7 @@ export default function evaluateRPN(val, ans) {
     }
 
     // output is the only value (hopefully) in the operand stack
-    const out = parseFloat(operands[0].toFixed(3));
+    const out = operands[0].toString();
 
     return out;
 }


### PR DESCRIPTION
The backspace key now operates the backspace function. This has resulted in a couple of minor changes. Most notably, the ANS function is now represented with "A", so that the letters can't be separated, thus causing incorrect syntax. The other notable change is evaluateRPN now returns a string of the evaluated value rather than a float, so that evaluated can be backspaced without crashing the page.