### PR TITLE
feat: add output field for equations

### DIFF
--- a/src/components/Calculator.js
+++ b/src/components/Calculator.js
@@ -5,6 +5,7 @@ import evaluateRPN from "./logic"
 export default function Calculator(props) {
     const [calcState, setCalcState] = React.useState("");
     const [answer, setAnswer] = React.useState("0");
+    const [displayOutput, setDisplayOutput] = React.useState(false)
 
     /**
      * Adds an operator or operand to calcState depending on 
@@ -16,6 +17,10 @@ export default function Calculator(props) {
      * handled.
      */
     function addToState(event) {
+        if(displayOutput) {
+            setDisplayOutput(false);
+        }
+
         if(event.type === "click") {
             // from button
             setCalcState(prevState => prevState + event.target.value);
@@ -46,8 +51,8 @@ export default function Calculator(props) {
     function equalsAction() {
         const ans = evaluateRPN(calcState, answer);
 
-        setCalcState(ans);
         setAnswer(ans);
+        setDisplayOutput(true);
     }
 
     /**
@@ -57,6 +62,7 @@ export default function Calculator(props) {
      * need it in other equations.
      */
     function clearAction() {
+        setDisplayOutput(false);
         setCalcState("");
     }
 
@@ -65,6 +71,7 @@ export default function Calculator(props) {
      * calcState.
      */
     function backAction() {
+        setDisplayOutput(false);
         setCalcState(prevState => prevState.slice(0, prevState.length - 1));
     }
 
@@ -84,12 +91,14 @@ export default function Calculator(props) {
 
     return (
         <div className="calculator">
-            <input 
-                type="text" 
-                className="calculator--screen"
-                value={calcState}
-                readOnly={true}
-            />
+            <div className="calculator--screen">
+                <p className="calculator--screen--input">{calcState}</p>
+                <p className="calculator--screen--output">
+                    {
+                        displayOutput && "=" + answer
+                    }
+                </p>
+            </div>
             <div className="calculator--input">
                 <span className="number-row">
                     <NumberButton style={props.style} value={"1"} onClick={addToState} />

--- a/src/style.css
+++ b/src/style.css
@@ -11,17 +11,6 @@ main {
     flex-direction: column;
 }
 
-.calculator {
-    max-width: 500px;
-    min-width: 400px;
-    width: 60%;
-    align-self: center;
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-    margin-top: 20px;
-}
-
 footer {
     font-size: smaller;
     position: fixed;
@@ -47,13 +36,38 @@ footer {
     color: grey;
 }
 
+.calculator {
+    max-width: 500px;
+    min-width: 400px;
+    width: 60%;
+    align-self: center;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-top: 20px;
+}
+
 .calculator--screen {
-    padding: 20px;
+    padding: 10px;
     font-size: 32px;
     border: 1px solid black;
+    border-radius: 10px;
+}
+
+.calculator--screen--input {
+    margin: 0;
+    min-height: 50px;
+    font-size: 32px;
     cursor: default;
     outline: none;
     border-radius: 10px;
+    overflow-x: scroll;    
+}
+
+.calculator--screen--output {
+    min-height: 40px;
+    margin: 0;
+    text-align: right;
 }
 
 .calculator--input {


### PR DESCRIPTION
Added a field for output for evaluated equations. This has resulted in some slight restructuring of the layout of the calculator's screen - namely, the single input field has been replaced by an "input" p element, which displays current input, and an output p element, which displays the most recent evaluation. The latter element will display upon evaluating the equation, and will disappear upon doing any other calculator action.
These additions have also solved the issue of input overflow, since the input p element has a vertical scrollbar.