### PR TITLE
bug: fix lack of sanity checking

### DIFF
--- a/src/components/Calculator.js
+++ b/src/components/Calculator.js
@@ -1,11 +1,13 @@
 import {React, useState, useEffect} from "react"
 import NumberButton from "./NumberButton"
 import evaluateRPN from "./logic"
+import {ImCross} from "react-icons/im"
 
 export default function Calculator({isNight}) {
     const [calcState, setCalcState] = useState("");
     const [answer, setAnswer] = useState("0");
     const [displayOutput, setDisplayOutput] = useState(false);
+    const [error, setError] = useState("");
 
     /**
      * Adds an operator or operand to calcState depending on 
@@ -56,10 +58,15 @@ export default function Calculator({isNight}) {
      * the returned value.
      */
     function equalsAction() {
+        setError("");
         const ans = evaluateRPN(calcState, answer);
 
-        setAnswer(ans);
-        setDisplayOutput(true);
+        if(isNaN(ans)) {
+            setError("Error: Incorrect syntax");
+        } else {
+            setAnswer(ans);
+            setDisplayOutput(true);
+        }
     }
 
     /**
@@ -98,6 +105,12 @@ export default function Calculator({isNight}) {
 
     return (
         <div className="calculator">
+            {error && 
+                <div className="error-box">
+                    <ImCross className="error--icon" onClick={() => setError("")} />
+                    <p>{error}</p>
+                </div>
+            }
             <div className={isNight ? "calculator--screen--night" : "calculator--screen--day"}>
                 <p className="calculator--screen--input">{calcState}</p>
                 <p className="calculator--screen--output">

--- a/src/components/logic.js
+++ b/src/components/logic.js
@@ -53,8 +53,9 @@ function inputToRPN(val, ans) {
                 && isLeftAssoc(curr));
 
             while(opStack[opStack.length - 1] !== undefined && canPopOperators) {
-                    outQueue.push(opStack.pop());
-                }
+                outQueue.push(opStack.pop());
+            }
+
             opStack.push(curr);
         } else {
             // operand case, always pushed to output

--- a/src/style.css
+++ b/src/style.css
@@ -215,3 +215,31 @@ article {
 .header--toggle {
     margin: 5px;
 }
+
+.error-box {
+    display: flex;
+    flex-direction: column;
+    color: white;
+    text-align: center;
+    background-color: rgb(255, 40, 40);
+    font-size: 20px;
+    padding: 10px;
+}
+
+.error-box > p {
+    margin: 10px;
+    font-weight: bold;
+}
+
+.error--icon {
+    align-self: flex-end;
+    font-size: small;
+}
+
+.error--icon:hover {
+    color: rgb(219, 219, 219);
+}
+
+.error--icon:active {
+    color: rgb(126, 126, 126);
+}


### PR DESCRIPTION
Add basic sanity checking. If evaluateRPN returns NaN, display an error message and don't set answer or screen output.